### PR TITLE
Fix squigglepy

### DIFF
--- a/squigglepy/samples.py
+++ b/squigglepy/samples.py
@@ -5,8 +5,8 @@ p_a = 0.8
 p_b = 0.5
 p_c = p_a * p_b
 
-dist_0 = sq.discrete({0: 1})
-dist_1 = sq.discrete({1: 1})
+dist_0 = 0
+dist_1 = 1
 dist_some = sq.to(1, 3)
 dist_many = sq.to(2, 10)
 


### PR DESCRIPTION
Corrects the "ValueError: You cannot nest discrete distributions within mixture distributions"

I get `4.61s user 0.22s system 294% cpu 1.639 total` not super sure how to read that tbh

Multicore would be faster it looks like if you want that too... I get `4.65s user 0.33s system 362% cpu 1.372 total` when running on 5 core

I have M2 chip

BTW there was a huge speedup to mixture sampling in v0.21 so I'd definitely recommend upgrading